### PR TITLE
iOS 13 for background push mandatory changes are added

### DIFF
--- a/CorePush/Apple/ApnSender.cs
+++ b/CorePush/Apple/ApnSender.cs
@@ -63,7 +63,8 @@ namespace CorePush.Apple
             string deviceToken,
             string apnsId = null,
             int apnsExpiration = 0,
-            int apnsPriority = 10)
+            int apnsPriority = 10,
+            bool isBackground = false)
         {
             var path = $"/3/device/{deviceToken}";
             var json = JsonHelper.Serialize(notification);
@@ -79,6 +80,7 @@ namespace CorePush.Apple
             request.Headers.Add("apns-topic", appBundleIdentifier);
             request.Headers.Add("apns-expiration", apnsExpiration.ToString());
             request.Headers.Add("apns-priority", apnsPriority.ToString());
+            request.Headers.Add("apns-push-type", isBackground ? "background" : "alert"); // for iOS 13 required
             if (!string.IsNullOrWhiteSpace(apnsId))
             {
                 request.Headers.Add(apnidHeader, apnsId);


### PR DESCRIPTION
for iOS 13, Apple made some breaking changes, check it out: https://onesignal.com/blog/ios-13-introduces-4-breaking-changes-to-notifications/
So adding the header "apns-push-type" resolved this issue.