### PR TITLE
Mismatching arguments in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For Firebase messages we will need project Server Key and Sender ID. If you are 
 ```csharp
 using (var fcm = new FcmSender(serverKey, senderId))
 {
-    await fcm.SendAsync(notification, deviceToken);
+    await fcm.SendAsync(deviceToken, notification);
 }
 ```
 If you want to use Firebase to send iOS notifications, please checkout this article: https://firebase.google.com/docs/cloud-messaging/ios/certs.
@@ -43,7 +43,7 @@ To send notifications to Apple devices you have to create a publisher profile an
 ```csharp
 using (var apn = new ApnSender(p8privateKey, p8privateKeyId, teamId, appBundleIdentifier, server)) 
 {
-    await apn.SendAsync(deviceToken, notification);
+    await apn.SendAsync(notification, deviceToken);
 }
 ```
 **IMPORTANT 1**: Initialize 1 ApnSender per bundle, send messages and don't forget to dispose your object. When you send many messages at once make sure to retry the sending in case of an error. If error happens it's recommended to retry the call after 1 second delay (await Task.Delay(1000)). Apple typically doesn't like to receive too many messages and will ocasionally respond with HTTP 429. From my experiance it happens once per 1000 requests.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For Firebase messages we will need project Server Key and Sender ID. If you are 
 ```csharp
 using (var fcm = new FcmSender(serverKey, senderId))
 {
-    await fcm.SendAsync(deviceToken, notification);
+    await fcm.SendAsync(notification, deviceToken);
 }
 ```
 If you want to use Firebase to send iOS notifications, please checkout this article: https://firebase.google.com/docs/cloud-messaging/ios/certs.


### PR DESCRIPTION
I found that SendAsync in APN takes notification first, then deviceToken.