### PR TITLE
Forced capitalization removed in JsonHelper. 

### DIFF
--- a/CorePush/Utils/JsonHelper.cs
+++ b/CorePush/Utils/JsonHelper.cs
@@ -6,8 +6,7 @@ namespace CorePush.Utils
     public static class JsonHelper
     {
         private static readonly JsonSerializerSettings settings = new JsonSerializerSettings
-        {
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        { 
             NullValueHandling = NullValueHandling.Ignore,
         };
 


### PR DESCRIPTION
Forced capitalization removed. Because it modifies the data that was sent in the payload.