### PR TITLE
Related to issue #41 - JWT token improvement if 403 error, plus JWT token handling to be via an interface

### DIFF
--- a/CorePush/Apple/ApnSender.cs
+++ b/CorePush/Apple/ApnSender.cs
@@ -21,6 +21,7 @@ namespace CorePush.Apple
             {ApnServerType.Development, "https://api.sandbox.push.apple.com:443" },
             {ApnServerType.Production, "https://api.push.apple.com:443" }
         };
+        private static readonly IJwtTokenProvider defaultJwtTokenProvider = new DefaultJwtTokenProvider();
 
         private const string apnidHeader = "apns-id";
 
@@ -54,13 +55,10 @@ namespace CorePush.Apple
             int apnsPriority = 10,
             bool isBackground = false,
             int maxRetries=0,
-            IJwtTokenProvider jwtProvider = null)
+            IJwtTokenProvider jwtProviderOverride = null)
         {
 
-            if (jwtProvider == null)
-            {
-                jwtProvider = new DefaultJwtTokenProvider();
-            }
+            var jwtProvider = jwtProviderOverride != null ? jwtProviderOverride : defaultJwtTokenProvider;
 
             var path = $"/3/device/{deviceToken}";
             var json = JsonHelper.Serialize(notification);

--- a/CorePush/Apple/ApnSender.cs
+++ b/CorePush/Apple/ApnSender.cs
@@ -18,7 +18,7 @@ namespace CorePush.Apple
     {
         private static readonly Dictionary<ApnServerType, string> servers = new Dictionary<ApnServerType, string>
         {
-            {ApnServerType.Development, "https://api.development.push.apple.com:443" },
+            {ApnServerType.Development, "https://api.sandbox.push.apple.com:443" },
             {ApnServerType.Production, "https://api.push.apple.com:443" }
         };
 

--- a/CorePush/Apple/ApnsResponse.cs
+++ b/CorePush/Apple/ApnsResponse.cs
@@ -6,6 +6,8 @@ namespace CorePush.Apple
 {
     public class ApnsResponse
     {
+        public int StatusCode;
+
         public bool IsSuccess { get; set;  }
 
         public ApnsError Error { get; set; }

--- a/CorePush/Apple/AppleNotification.cs
+++ b/CorePush/Apple/AppleNotification.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace CorePush.Apple
+{
+    public class AppleNotification
+    {
+        public class AlertPayload
+        {
+            [JsonProperty("title")]
+            public string Title { get; set; }
+
+            [JsonProperty("subtitle")]
+            public string SubTitle { get; set; }
+
+            [JsonProperty("body")]
+            public string Body { get; set; }
+
+        }
+
+        public class ApsPayload
+        {
+            [JsonProperty("alert")]
+            public AlertPayload Alert { get; set; }
+        }
+
+        [JsonProperty("aps")]
+        public ApsPayload Aps { get; set; }
+
+        // Your custom properties as needed
+        // Note that before sending this to apple it's moved from 'data'
+        // so that each key is a peer in AppleNotification instead.  I'm sure
+        // there's a custom JSON read/writer that we could create, but this
+        // is the easiest way I could think of to achieve this for now.
+        [JsonProperty("data")]
+        public Dictionary<string, string> Data {get; set;}
+    }
+}

--- a/CorePush/Apple/DefaultJwtTokenProvider.cs
+++ b/CorePush/Apple/DefaultJwtTokenProvider.cs
@@ -44,5 +44,9 @@ namespace CorePush.Apple
             return Convert.ToInt32(span.TotalSeconds);
         }
 
+        public void ClearJwtToken(ApnSettings settings)
+        {
+            tokens.TryRemove(settings.AppBundleIdentifier, out _);
+        }
     }
 }

--- a/CorePush/Apple/DefaultJwtTokenProvider.cs
+++ b/CorePush/Apple/DefaultJwtTokenProvider.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using CorePush.Interfaces;
+using CorePush.Utils;
+
+namespace CorePush.Apple
+{
+    public class DefaultJwtTokenProvider : IJwtTokenProvider
+    {
+        private static readonly ConcurrentDictionary<string, Tuple<string, DateTime>> tokens = new ConcurrentDictionary<string, Tuple<string, DateTime>>();
+        private const int tokenExpiresMinutes = 50;
+
+        public string GetJwtToken(ApnSettings settings)
+        {
+            var (token, date) = tokens.GetOrAdd(settings.AppBundleIdentifier, _ => new Tuple<string, DateTime>(CreateJwtToken(settings), DateTime.UtcNow));
+            if (date < DateTime.UtcNow.AddMinutes(-tokenExpiresMinutes))
+            {
+                tokens.TryRemove(settings.AppBundleIdentifier, out _);
+                return GetJwtToken(settings);
+            }
+
+            return token;
+        }
+
+        public string CreateJwtToken(ApnSettings settings)
+        {
+            var header = JsonHelper.Serialize(new { alg = "ES256", kid = settings.P8PrivateKeyId });
+            var payload = JsonHelper.Serialize(new { iss = settings.TeamId, iat = ToEpoch(DateTime.UtcNow) });
+            var headerBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(header));
+            var payloadBasae64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(payload));
+            var unsignedJwtData = $"{headerBase64}.{payloadBasae64}";
+            var unsignedJwtBytes = Encoding.UTF8.GetBytes(unsignedJwtData);
+            using var dsa = ECDsa.Create();
+            dsa.ImportPkcs8PrivateKey(Convert.FromBase64String(settings.P8PrivateKey), out _);
+            var signature = dsa.SignData(unsignedJwtBytes, 0, unsignedJwtBytes.Length, HashAlgorithmName.SHA256);
+            return $"{unsignedJwtData}.{Convert.ToBase64String(signature)}";
+        }
+
+        private static int ToEpoch(DateTime time)
+        {
+            var span = DateTime.UtcNow - new DateTime(1970, 1, 1);
+            return Convert.ToInt32(span.TotalSeconds);
+        }
+
+    }
+}

--- a/CorePush/Interfaces/IApnSender.cs
+++ b/CorePush/Interfaces/IApnSender.cs
@@ -7,10 +7,10 @@ namespace CorePush.Interfaces
     public interface IApnSender
     {
         Task<ApnsResponse> SendAsync(
-            object notification,
+            AppleNotification notification,
             string deviceToken,
             string apnsId = null,
-            int apnsExpiration = 0,
+            long apnsExpiration = 0,
             int apnsPriority = 10,
             bool isBackground = false,
             int maxRetries = 0,

--- a/CorePush/Interfaces/IApnSender.cs
+++ b/CorePush/Interfaces/IApnSender.cs
@@ -12,6 +12,7 @@ namespace CorePush.Interfaces
             string apnsId = null,
             int apnsExpiration = 0,
             int apnsPriority = 10,
-            bool isBackground = false);
+            bool isBackground = false,
+            IJwtTokenProvider jwtProvider = null);
     }
 }

--- a/CorePush/Interfaces/IApnSender.cs
+++ b/CorePush/Interfaces/IApnSender.cs
@@ -13,6 +13,7 @@ namespace CorePush.Interfaces
             int apnsExpiration = 0,
             int apnsPriority = 10,
             bool isBackground = false,
+            int maxRetries = 0,
             IJwtTokenProvider jwtProvider = null);
     }
 }

--- a/CorePush/Interfaces/IJwtTokenProvider.cs
+++ b/CorePush/Interfaces/IJwtTokenProvider.cs
@@ -5,6 +5,7 @@ namespace CorePush.Interfaces
 {
     public interface IJwtTokenProvider
     {
+        void ClearJwtToken(ApnSettings settings);
         string CreateJwtToken(ApnSettings settings);
         string GetJwtToken(ApnSettings settings);
     }

--- a/CorePush/Interfaces/IJwtTokenProvider.cs
+++ b/CorePush/Interfaces/IJwtTokenProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using CorePush.Apple;
+
+namespace CorePush.Interfaces
+{
+    public interface IJwtTokenProvider
+    {
+        string CreateJwtToken(ApnSettings settings);
+        string GetJwtToken(ApnSettings settings);
+    }
+}


### PR DESCRIPTION
Related to issue #41 - I had to close the last pull request because I hadn't initialised the default JWT token provider as a static which meant that the in-memory cache would be cleared each time.

In addition 

- Changed to 'sanbox' as per the official apple docs
- Ability to get status code back
- Retries on failure
- Ability to clear JWT token if 403 failure
