### PR TITLE
Support .NET Standard 2.0 through multitarget build

### DIFF
--- a/CorePush/CorePush.csproj
+++ b/CorePush/CorePush.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <Description>.NET Core C# Push Notifications for Android Google Firebase Messaging (FCM) and Apple push notifications (APN).</Description>
     <Authors>Andrei M</Authors>
     <Company />
@@ -41,4 +41,17 @@ Previous Versions:
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.9" />
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>NETSTANDARD2_0</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
+    <DefineConstants>NETSTANDARD2_1</DefineConstants>
+  </PropertyGroup>
+  
 </Project>

--- a/CorePush/Google/FcmSender.cs
+++ b/CorePush/Google/FcmSender.cs
@@ -39,15 +39,20 @@ namespace CorePush.Google
             jsonObject.Add("to", JToken.FromObject(deviceId));
             var json = jsonObject.ToString();
 
-            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, fcmUrl);
-            httpRequest.Headers.Add("Authorization", $"key = {settings.ServerKey}");
-            httpRequest.Headers.Add("Sender", $"id = {settings.SenderId}");
-            httpRequest.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            using var response = await http.SendAsync(httpRequest);
-            response.EnsureSuccessStatusCode();
-            var responseString = await response.Content.ReadAsStringAsync();
+            using (var httpRequest = new HttpRequestMessage(HttpMethod.Post, fcmUrl))
+            {
+                httpRequest.Headers.Add("Authorization", $"key = {settings.ServerKey}");
+                httpRequest.Headers.Add("Sender", $"id = {settings.SenderId}");
+                httpRequest.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
-            return JsonHelper.Deserialize<FcmResponse>(responseString);
+                using (var response = await http.SendAsync(httpRequest))
+                {
+                    response.EnsureSuccessStatusCode();
+                    var responseString = await response.Content.ReadAsStringAsync();
+
+                    return JsonHelper.Deserialize<FcmResponse>(responseString);
+                }
+            }
         }
     }
 }

--- a/CorePush/Utils/AppleCryptoHelper.cs
+++ b/CorePush/Utils/AppleCryptoHelper.cs
@@ -1,0 +1,51 @@
+﻿
+using System;
+using System.Security.Cryptography;
+
+#if NETSTANDARD2_0
+using Org.BouncyCastle.Crypto.Parameters;	
+using Org.BouncyCastle.Security;
+#endif
+
+namespace CorePush.Utils
+{
+    public static class AppleCryptoHelper
+    {
+#if NETSTANDARD2_1
+        public static ECDsa GetEllipticCurveAlgorithm(string privateKey)
+        {
+            var dsa = ECDsa.Create();
+
+            try
+            {
+                dsa.ImportPkcs8PrivateKey(Convert.FromBase64String(privateKey), out _);
+                return dsa;
+            }
+            catch
+            {
+                dsa.Dispose();
+                throw;
+            }
+        }
+#endif
+
+#if NETSTANDARD2_0
+        public static ECDsa GetEllipticCurveAlgorithm(string privateKey)	
+        {	
+            var keyParams = (ECPrivateKeyParameters) PrivateKeyFactory.CreateKey(Convert.FromBase64String(privateKey));	
+            var q = keyParams.Parameters.G.Multiply(keyParams.D).Normalize();	
+
+            return ECDsa.Create(new ECParameters	
+            {	
+                Curve = ECCurve.CreateFromValue(keyParams.PublicKeyParamSet.Id),	
+                D = keyParams.D.ToByteArrayUnsigned(),	
+                Q =	
+                {	
+                    X = q.XCoord.GetEncoded(),	
+                    Y = q.YCoord.GetEncoded()	
+                }	
+            });	
+        }
+#endif
+    }
+}


### PR DESCRIPTION
This solves #44.

It keeps support for both .NET Standard 2.0 and 2.1.

The older code for Bouncycastle has been revived, and put in a compiler macro so it is only required and used in 2.0. The .NET Core functions are used in Standard 2.1.

This has zero effect on the target code for .NET Standard 2.1.