### PR TITLE
Revert to BouncyCastle for .NET Standard 2.0 support

### DIFF
--- a/CorePush/CorePush.csproj
+++ b/CorePush/CorePush.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>.NET Core C# Push Notifications for Android Google Firebase Messaging (FCM) and Apple push notifications (APN).</Description>
     <Authors>Andrei M</Authors>
     <Company />
@@ -39,6 +39,7 @@ Previous Versions:
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.9" />
   </ItemGroup>
-
+  
 </Project>

--- a/CorePush/Google/FcmSender.cs
+++ b/CorePush/Google/FcmSender.cs
@@ -39,15 +39,20 @@ namespace CorePush.Google
             jsonObject.Add("to", JToken.FromObject(deviceId));
             var json = jsonObject.ToString();
 
-            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, fcmUrl);
-            httpRequest.Headers.Add("Authorization", $"key = {settings.ServerKey}");
-            httpRequest.Headers.Add("Sender", $"id = {settings.SenderId}");
-            httpRequest.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            using var response = await http.SendAsync(httpRequest);
-            response.EnsureSuccessStatusCode();
-            var responseString = await response.Content.ReadAsStringAsync();
+            using (var httpRequest = new HttpRequestMessage(HttpMethod.Post, fcmUrl))
+            {
+                httpRequest.Headers.Add("Authorization", $"key = {settings.ServerKey}");
+                httpRequest.Headers.Add("Sender", $"id = {settings.SenderId}");
+                httpRequest.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
-            return JsonHelper.Deserialize<FcmResponse>(responseString);
+                using (var response = await http.SendAsync(httpRequest))
+                {
+                    response.EnsureSuccessStatusCode();
+                    var responseString = await response.Content.ReadAsStringAsync();
+
+                    return JsonHelper.Deserialize<FcmResponse>(responseString);
+                }
+            }
         }
     }
 }

--- a/CorePush/Utils/AppleCryptoHelper.cs
+++ b/CorePush/Utils/AppleCryptoHelper.cs
@@ -1,0 +1,28 @@
+﻿
+using System;
+using System.Security.Cryptography;
+using Org.BouncyCastle.Crypto.Parameters;	
+using Org.BouncyCastle.Security;
+
+namespace CorePush.Utils
+{
+    public static class AppleCryptoHelper
+    {
+        public static ECDsa GetEllipticCurveAlgorithm(string privateKey)	
+        {	
+            var keyParams = (ECPrivateKeyParameters) PrivateKeyFactory.CreateKey(Convert.FromBase64String(privateKey));	
+            var q = keyParams.Parameters.G.Multiply(keyParams.D).Normalize();	
+
+            return ECDsa.Create(new ECParameters	
+            {	
+                Curve = ECCurve.CreateFromValue(keyParams.PublicKeyParamSet.Id),	
+                D = keyParams.D.ToByteArrayUnsigned(),	
+                Q =	
+                {	
+                    X = q.XCoord.GetEncoded(),	
+                    Y = q.YCoord.GetEncoded()	
+                }	
+            });	
+        }
+    }
+}


### PR DESCRIPTION
This solves #44 - without multiple targets, just BouncyCastle as suggested in #45.

