### PR TITLE
Cache apn private key and header

### DIFF
--- a/CorePush/Apple/ApnSettings.cs
+++ b/CorePush/Apple/ApnSettings.cs
@@ -1,16 +1,38 @@
+using System.Threading;
+
 namespace CorePush.Apple
 {
     public class ApnSettings
     {
+        private int _DataDirtyNonce = 0;
+        private string _P8PrivateKey;
+        private string _P8PrivateKeyId;
+
         /// <summary>
         /// p8 certificate string
         /// </summary>
-        public string P8PrivateKey { get; set; }
+        public string P8PrivateKey
+        {
+            get { return _P8PrivateKey; }
+            set
+            {
+                _P8PrivateKey = value;
+                Interlocked.Increment(ref _DataDirtyNonce);
+            }
+        }
 
         /// <summary>
         /// 10 digit p8 certificate id. Usually a part of a downloadable certificate filename
         /// </summary>
-        public string P8PrivateKeyId { get; set; } 
+        public string P8PrivateKeyId
+        {
+            get { return _P8PrivateKeyId; }
+            set
+            {
+                _P8PrivateKeyId = value;
+                Interlocked.Increment(ref _DataDirtyNonce);
+            }
+        }
 
         /// <summary>
         /// Apple 10 digit team id
@@ -26,5 +48,10 @@ namespace CorePush.Apple
         /// Development or Production server
         /// </summary>
         public ApnServerType ServerType { get; set; }
+
+        internal int GetDirtyNonce()
+        {
+            return _DataDirtyNonce;
+        }
     }
 }

--- a/CorePush/Utils/AppleCryptoHelper.cs
+++ b/CorePush/Utils/AppleCryptoHelper.cs
@@ -1,5 +1,6 @@
-﻿
-using System;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using Org.BouncyCastle.Crypto.Parameters;	
 using Org.BouncyCastle.Security;
@@ -22,7 +23,30 @@ namespace CorePush.Utils
                     X = q.XCoord.GetEncoded(),	
                     Y = q.YCoord.GetEncoded()	
                 }	
-            });	
+            });
+        }
+
+        public static string CleanP8Key(string p8Key)
+        {
+            // If we have an empty p8Key, then don't bother doing any tasks.
+            if (string.IsNullOrEmpty(p8Key))
+            {
+                return p8Key;
+            }
+
+            List<string> lines = p8Key.Split(new char[] { '\n' }).ToList();
+            if (0 != lines.Count && lines[0].StartsWith("-----BEGIN PRIVATE KEY-----"))
+            {
+                lines.RemoveAt(0);
+            }
+
+            if (0 != lines.Count && lines[lines.Count - 1].StartsWith("-----END PRIVATE KEY-----"))
+            {
+                lines.RemoveAt(lines.Count - 1);
+            }
+
+            string result = string.Join("", lines);
+            return result;
         }
     }
 }


### PR DESCRIPTION
Solves #46.

This takes care of caching the APN private key (instead of re-parsing it for each message, possible hundreds of thousands of times per second...).

It keeps everything thread safe, and will update the cache if the associated settings have mutated.

NOTE: This is based on #45. So that one should be merged first. If #44 is merged instead, I will rebase on it.