### PR TITLE
When generating JSON requests, allow preserving names specified using JsonProperty

### DIFF
--- a/CorePush/Utils/JsonHelper.cs
+++ b/CorePush/Utils/JsonHelper.cs
@@ -7,7 +7,10 @@ namespace CorePush.Utils
     {
         private static readonly JsonSerializerSettings settings = new JsonSerializerSettings
         {
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            ContractResolver = new CamelCasePropertyNamesContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy(true, false)
+            },
             NullValueHandling = NullValueHandling.Ignore,
         };
 


### PR DESCRIPTION
Currently camelCase naming is applied to all JSON properties, regardless of the case used in JsonProperty("CustomCASEProperty").
The proposed fix allows serialized JSON to contain arbitrary case names in custom properties.

Examples contain expected camelCase names so there should be no compatibility issues although if someone used the library and depended on changing MyCustomProperty to myCustomProperty, they will have to update custom names.

Hopefully you can include this change as otherwise use cases like mine, requiring specific case in JSON messages, will need to rely on a hack similar to the one below:

```
        private static void ConfigureJsonSerializer()
        {
            var settingsProperty = typeof(CorePush.Utils.JsonHelper).GetTypeInfo()
                .GetFields(BindingFlags.Static | BindingFlags.NonPublic)
                .FirstOrDefault(x => "settings".Equals(x.Name, StringComparison.OrdinalIgnoreCase));
            if (settingsProperty != null && settingsProperty.GetValue(null) is JsonSerializerSettings settings)
            {
                settings.ContractResolver = new CamelCasePropertyNamesContractResolver
                {
                    NamingStrategy = new CamelCaseNamingStrategy(true, false)
                };
            }
        }
```
