### PR TITLE
Support sending raw string APNS notifications.

### DIFF
--- a/CorePush/Apple/ApnSender.cs
+++ b/CorePush/Apple/ApnSender.cs
@@ -69,6 +69,13 @@ namespace CorePush.Apple
                 cancellationToken);
         }
 
+        /// <summary>
+        /// Sends a raw JSON string notification to APN. Please see how your message should be formatted here:
+        /// https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW1
+        /// !IMPORTANT: If you send many messages at once, make sure to retry those calls. Apple typically doesn't like
+        /// to receive too many requests and may occasionally respond with HTTP 429. Just try/catch this call and retry as needed.
+        /// </summary>
+        /// <exception cref="HttpRequestException">Throws exception when not successful</exception>
         public async Task<ApnsResponse> SendSerializedAsync(string notification, string deviceToken, string apnsId = null,
             int apnsExpiration = 0, int apnsPriority = 10, bool isBackground = false,
             CancellationToken cancellationToken = default)

--- a/CorePush/Apple/ApnSender.cs
+++ b/CorePush/Apple/ApnSender.cs
@@ -64,14 +64,21 @@ namespace CorePush.Apple
             bool isBackground = false,
             CancellationToken cancellationToken = default)
         {
-            var path = $"/3/device/{deviceToken}";
             var json = JsonHelper.Serialize(notification);
+            return await SendSerializedAsync(json, deviceToken, apnsId, apnsExpiration, apnsPriority, isBackground,
+                cancellationToken);
+        }
 
+        public async Task<ApnsResponse> SendSerializedAsync(string notification, string deviceToken, string apnsId = null,
+            int apnsExpiration = 0, int apnsPriority = 10, bool isBackground = false,
+            CancellationToken cancellationToken = default)
+        {
+            var path = $"/3/device/{deviceToken}";
             using (var message = new HttpRequestMessage(HttpMethod.Post, path))
             {
                 message.Version = new Version(2, 0);
-                message.Content = new StringContent(json);
-                
+                message.Content = new StringContent(notification);
+
                 message.Headers.Authorization = new AuthenticationHeaderValue("bearer", GetJwtToken());
                 message.Headers.TryAddWithoutValidation(":method", "POST");
                 message.Headers.TryAddWithoutValidation(":path", path);


### PR DESCRIPTION
For a current solution I need to pass on raw string APNS notifications. The current codebase always requires me to first deserialize these strings, only for them to be serialized slightly after. This pull request adds the ability to send these already serialized APNS notification payloads directly, without requiring deserialization first.